### PR TITLE
Convert to bytes via associated type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,20 @@
 [package]
 name = "endian-type"
-version = "0.1.2"
-authors = ["Lolirofle <lolipopple@hotmail.com>"]
-description = "Type safe wrappers for types with a defined byte order"
+version = "0.1.3"
+authors = ["Lolirofle <lolipopple@hotmail.com>","Jeffrey Burdges <burdges@gnunet.org>"]
+
+description = "Type safe wrappers for byte order with conversion from/to byte arrays."
 #documentation = "..."
+
 homepage = "https://github.com/Lolirofle/endian-type"
 repository = "https://github.com/Lolirofle/endian-type.git"
+
 #readme = "README.md"
+
 keywords = ["endian","byteorder"]
+
 license = "MIT"
+
+[dependencies]
+
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,30 @@ macro_rules! impl_EndianOps{
 	}
 }
 
+macro_rules! impl_for_Endian{
+	( $t:ident, $me:ident, $from_e:ident, $to_e:ident, $op:ident ) => {
+		impl Into<$t> for $me<$t>{
+			#[inline]
+			fn into(self) -> $t{
+				$t::$from_e(self.0)
+			}
+		}
+
+		impl From<$t> for $me<$t>{
+			#[inline]
+			fn from(data: $t) -> Self{
+				$me(data.$to_e())
+			}
+		}
+
+		impl From<$op<$t>> for $me<$t>{
+			#[inline]
+			fn from(data: $op<$t>) -> Self{
+				$me(data.0.swap_bytes())
+			}
+		}
+	}
+}
 
 
 ///Big endian byte order
@@ -82,37 +106,20 @@ impl<T> Endian<T> for BigEndian<T>{}
 
 macro_rules! impl_for_BigEndian{
 	( $t:ident ) => {
-		impl Into<$t> for BigEndian<$t>{
-			#[inline]
-			fn into(self) -> $t{
-				$t::from_be(self.0)
-			}
-		}
-
-		impl From<$t> for BigEndian<$t>{
-			#[inline]
-			fn from(data: $t) -> Self{
-				BigEndian(data.to_be())
-			}
-		}
-
-		impl From<LittleEndian<$t>> for BigEndian<$t>{
-			#[inline]
-			fn from(data: LittleEndian<$t>) -> Self{
-				BigEndian(data.0.swap_bytes())
-			}
-		}
+                impl_for_Endian!($t,BigEndian,from_be,to_be,LittleEndian);
 	}
 }
+
+impl_for_BigEndian!(usize);
+impl_for_BigEndian!(isize);
 
 impl_for_BigEndian!(u16);
 impl_for_BigEndian!(u32);
 impl_for_BigEndian!(u64);
-impl_for_BigEndian!(usize);
+
 impl_for_BigEndian!(i16);
 impl_for_BigEndian!(i32);
 impl_for_BigEndian!(i64);
-impl_for_BigEndian!(isize);
 
 
 
@@ -127,37 +134,19 @@ impl<T> Endian<T> for LittleEndian<T>{}
 
 macro_rules! impl_for_LittleEndian{
 	( $t:ident ) => {
-		impl Into<$t> for LittleEndian<$t>{
-			#[inline]
-			fn into(self) -> $t{
-				$t::from_le(self.0)
-			}
-		}
-
-		impl From<$t> for LittleEndian<$t>{
-			#[inline]
-			fn from(data: $t) -> Self{
-				LittleEndian(data.to_le())
-			}
-		}
-
-		impl From<BigEndian<$t>> for LittleEndian<$t>{
-			#[inline]
-			fn from(data: BigEndian<$t>) -> Self{
-				LittleEndian(data.0.swap_bytes())
-			}
-		}
+                impl_for_Endian!($t,LittleEndian,from_le,to_le,BigEndian);
 	}
 }
+
+impl_for_LittleEndian!(usize);
+impl_for_LittleEndian!(isize);
 
 impl_for_LittleEndian!(u16);
 impl_for_LittleEndian!(u32);
 impl_for_LittleEndian!(u64);
-impl_for_LittleEndian!(usize);
 impl_for_LittleEndian!(i16);
 impl_for_LittleEndian!(i32);
 impl_for_LittleEndian!(i64);
-impl_for_LittleEndian!(isize);
 
 
 ///Network byte order as defined by IETF RFC1700 [http://tools.ietf.org/html/rfc1700]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use core::ops::{BitAnd,BitOr,BitXor};
 ///Type with a specified byte order
 pub trait Endian<T>{}
 
-macro_rules! impl_Endian{
+macro_rules! impl_EndianOps{
 	( for $e:ident) => {
 		impl<T> BitAnd for $e<T>
 			where T: BitAnd
@@ -76,7 +76,10 @@ macro_rules! impl_Endian{
 ///Most significant byte first
 #[derive(Copy,Clone,Debug,Eq,PartialEq,Hash,Ord,PartialOrd)]
 pub struct BigEndian<T>(T);
+impl_EndianOps!(for BigEndian);
+
 impl<T> Endian<T> for BigEndian<T>{}
+
 macro_rules! impl_for_BigEndian{
 	( $t:ident ) => {
 		impl Into<$t> for BigEndian<$t>{
@@ -101,7 +104,7 @@ macro_rules! impl_for_BigEndian{
 		}
 	}
 }
-impl_Endian!(for BigEndian);
+
 impl_for_BigEndian!(u16);
 impl_for_BigEndian!(u32);
 impl_for_BigEndian!(u64);
@@ -118,7 +121,10 @@ impl_for_BigEndian!(isize);
 ///Least significant byte first
 #[derive(Copy,Clone,Debug,Eq,PartialEq,Hash,Ord,PartialOrd)]
 pub struct LittleEndian<T>(T);
+impl_EndianOps!(for LittleEndian);
+
 impl<T> Endian<T> for LittleEndian<T>{}
+
 macro_rules! impl_for_LittleEndian{
 	( $t:ident ) => {
 		impl Into<$t> for LittleEndian<$t>{
@@ -143,7 +149,7 @@ macro_rules! impl_for_LittleEndian{
 		}
 	}
 }
-impl_Endian!(for LittleEndian);
+
 impl_for_LittleEndian!(u16);
 impl_for_LittleEndian!(u32);
 impl_for_LittleEndian!(u64);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,11 @@
-use std::{mem,slice};
-use std::convert::{From,Into};
-use std::ops::{BitAnd,BitOr,BitXor};
+
+extern crate core;
+
+// use core::intrinsics::transmute;
+use core::{mem,slice};
+// use core::mem::size_of;
+use core::convert::{From,Into};
+use core::ops::{BitAnd,BitOr,BitXor};
 
 ///Type with a specified byte order
 pub trait Endian<T>{}


### PR DESCRIPTION
This adds a `::Bytes` associated type along with `Into` and `From` instances. 

In fact, I'm no longer completely sure if the `struct Endiannes<T>(T);` approach taken by this crate always makes the most sense :  
- Ain't likely you'll want this for floats, which require you transmute them into unsigned integers, convert their endianness, and transmute them back. 
- One cannot implement every `From` instance, although maybe this does not matter.  
- It's obnoxious to write `<LittleEndian<T> as Endian<T>>::Bytes`, so you want a macro, but if you use a macro then you can do almost anything. 

We might try this alternative formulation instead 

```
struct LittleEndianBytes<T>(<LittleEndian<T> as Endian<T>>::Bytes)
    where LittleEndian<T>: Endian<T>;
```

so users can access the bytes with `.0` and all the conversions happen with `into` and `from` calls the converted to the integer representation.  There is seemingly no way to shorten the trail of traits one needs to define this however.  And one must take care if trying to make this polymorphic on endianness due to rust's lack of higher kinded types. 
