### PR TITLE
Enable building in no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ repository = "https://github.com/Lolirofle/endian-type.git"
 #readme = "README.md"
 keywords = ["endian","byteorder"]
 license = "MIT"
+
+[features]
+default = ["std"]
+std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,13 @@
-use std::{mem,slice};
-use std::convert::{From,Into};
-use std::ops::{BitAnd,BitOr,BitXor};
+// Build without default features in order to include this library in #![no_std]
+// crates.
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+extern crate core;
+
+use core::{mem,slice};
+use core::convert::{From,Into};
+use core::ops::{BitAnd,BitOr,BitXor};
 
 ///Type with a specified byte order
 pub trait Endian<T>{}


### PR DESCRIPTION
By default build for the typtical std environment.

Default options may be disabled either by a "default-features = false"
entry in Cargo.tonl or "cargo build --no-default-features". This will
cause the library to build for a no_std environment.

Signed-off-by: Sean Wilson <spwilson27@gmail.com>