### PR TITLE
Replace Into with From for built-in types.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,10 +74,10 @@ pub struct BigEndian<T>(T);
 impl<T> Endian<T> for BigEndian<T>{}
 macro_rules! impl_for_BigEndian{
 	( $t:ident ) => {
-		impl Into<$t> for BigEndian<$t>{
+		impl From<BigEndian<$t>> for $t {
 			#[inline]
-			fn into(self) -> $t{
-				$t::from_be(self.0)
+			fn from(data: BigEndian<$t>) -> $t {
+				$t::from_be(data.0)
 			}
 		}
 
@@ -116,10 +116,10 @@ pub struct LittleEndian<T>(T);
 impl<T> Endian<T> for LittleEndian<T>{}
 macro_rules! impl_for_LittleEndian{
 	( $t:ident ) => {
-		impl Into<$t> for LittleEndian<$t>{
+		impl From<LittleEndian<$t>> for $t {
 			#[inline]
-			fn into(self) -> $t{
-				$t::from_le(self.0)
+			fn from(data: LittleEndian<$t>) -> $t {
+				$t::from_le(data.0)
 			}
 		}
 


### PR DESCRIPTION
https://doc.rust-lang.org/std/convert/trait.Into.html

Prior to Rust 1.41, if the destination type was not part of the current
crate then you couldn't implement From directly. This will fail to
compile in older versions of the language because Rust's orphaning rules
used to be a little bit more strict. To bypass this, you could implement
Into directly.

It is important to understand that Into does not provide a From
implementation (as From does with Into). Therefore, you should always
try to implement From and then fall back to Into if From can't be
implemented.

Signed-off-by: Sean Wilson <spwilson27@gmail.com>