### PR TITLE
Add definitions for simplified casting via "num"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "endian-type"
 version = "0.1.2"
-authors = ["Lolirofle <lolipopple@hotmail.com>"]
+authors = ["Lolirofle <lolipopple@hotmail.com>", "Sean Wilson <spwilson27@gmail.com>"]
 description = "Type safe wrappers for types with a defined byte order"
 #documentation = "..."
 homepage = "https://github.com/Lolirofle/endian-type"
@@ -9,3 +9,12 @@ repository = "https://github.com/Lolirofle/endian-type.git"
 #readme = "README.md"
 keywords = ["endian","byteorder"]
 license = "MIT"
+
+[features]
+default = ["std", "use_num"]
+std = []
+use_num = []
+
+[dependencies.num]
+version = "0.2.1"
+default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "use_num")]
+extern crate num;
+
 use std::{mem,slice};
 use std::convert::{From,Into};
 use std::ops::{BitAnd,BitOr,BitXor};
@@ -81,6 +84,17 @@ macro_rules! impl_for_BigEndian{
 			}
 		}
 
+        #[cfg(feature = "use_num")]
+        impl num::ToPrimitive for BigEndian<$t> {
+            fn to_i64(&self) -> Option<i64> {
+                Some($t::from_be(self.0) as i64)
+            }
+
+            fn to_u64(&self) -> Option<u64> {
+                Some($t::from_be(self.0) as u64)
+            }
+        }
+
 		impl From<$t> for BigEndian<$t>{
 			#[inline]
 			fn from(data: $t) -> Self{
@@ -136,6 +150,17 @@ macro_rules! impl_for_LittleEndian{
 				LittleEndian(data.0.swap_bytes())
 			}
 		}
+
+        #[cfg(feature = "use_num")]
+        impl num::ToPrimitive for LittleEndian<$t> {
+            fn to_i64(&self) -> Option<i64> {
+                Some($t::from_le(self.0) as i64)
+            }
+
+            fn to_u64(&self) -> Option<u64> {
+                Some($t::from_le(self.0) as u64)
+            }
+        }
 	}
 }
 impl_Endian!(for LittleEndian);


### PR DESCRIPTION
Previously casting between the internal types and another built-in
numeric type required a decent amount of boilerplate. In the worst case
you needed to specify both the current Big/LittleEndian's underlying
type as well as the type you were trying to cast to. E.g.

    let val: u32_be = u32_be::from(10);
    let addr = u32::from(val) as usize;

This isn't much overhead here where the type is obvious, however if you
change the underlying type of "val" in the above example, you must
change every single cast. Now the above becomes:

    let val: u32_be = u32_be::from(10);
    let addr = val.to_usize().unwrap();

Signed-off-by: Sean Wilson <spwilson27@gmail.com>