### PR TITLE
feat: update to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "endian-type"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Lolirofle <lolipopple@hotmail.com>"]
-description = "Type safe wrappers for types with a defined byte order"
-#documentation = "..."
-homepage = "https://github.com/Lolirofle/endian-type"
-repository = "https://github.com/Lolirofle/endian-type.git"
-#readme = "README.md"
-keywords = ["endian","byteorder"]
+categories = ["compression", "encoding", "parser-implementations"]
+edition = "2021"
+keywords = ["byteorder", "endian", "no_std"]
 license = "MIT"
+readme = "README.md"
+repository = "https://github.com/Lolirofle/endian-type.git"
+description = "Type safe wrappers for types with a defined byte order"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# endian-type
+
+[![crates.io](https://img.shields.io/crates/v/endian-type?label=latest)](https://crates.io/crates/endian-type)
+[![Documentation](https://docs.rs/endian-type/badge.svg)](https://docs.rs/endian-type/)
+[![License](https://img.shields.io/crates/l/endian-type.svg)]()
+
+Type safe wrappers for types with a defined byte order.
+
+### Example
+
+```rust
+use endian_type::{types, BigEndian, LittleEndian, NetworkOrder};
+
+// the endianness reflects the type-safety of the declaration
+let foo = 0xbeef_u32;
+let foo_be = BigEndian::from(foo);
+assert_eq!(foo_be.as_bytes(), &foo.to_be_bytes());
+
+// the deref implementations will allow you to operate the wrapped types as if they are regular
+// numbers
+let foo = u128::MAX;
+let foo_le = LittleEndian::from(foo);
+assert_eq!(foo_le.wrapping_add(1), 0);
+
+// we also have a couple of aliases to be used as helper
+//
+// this will assert our `NetworkOrder` type is in accordance with the IETF RFC1700
+let foo = -0xdead_i32;
+let foo_no = NetworkOrder::from(foo);
+let foo_be = types::i32_be::from(foo);
+assert_eq!(foo.to_be_bytes(), foo_no.as_bytes());
+assert_eq!(foo.to_be_bytes(), foo_be.as_bytes());
+```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,203 +1,222 @@
-use std::{mem,slice};
-use std::convert::{From,Into};
-use std::ops::{BitAnd,BitOr,BitXor};
+#![no_std]
+
+use core::ops::{BitAnd, BitOr, BitXor, Deref, DerefMut};
+use core::{mem, slice};
 
 ///Type with a specified byte order
-pub trait Endian<T>{}
+pub trait Endian<T> {}
 
 macro_rules! impl_Endian{
-	( for $e:ident) => {
-		impl<T> BitAnd for $e<T>
-			where T: BitAnd
-		{
-			type Output = $e<<T as BitAnd>::Output>;
+    ( for $e:ident) => {
+        impl<T> BitAnd for $e<T>
+        where
+            T: BitAnd,
+        {
+            type Output = $e<<T as BitAnd>::Output>;
 
-			#[inline]
-			fn bitand(self,other: Self) -> Self::Output{
-				$e(self.0 & other.0)
-			}
-		}
-		impl<T> BitOr for $e<T>
-			where T: BitOr
-		{
-			type Output = $e<<T as BitOr>::Output>;
+            #[inline]
+            fn bitand(self, other: Self) -> Self::Output {
+                $e(self.0 & other.0)
+            }
+        }
 
-			#[inline]
-			fn bitor(self,other: Self) -> Self::Output{
-				$e(self.0 | other.0)
-			}
-		}
-		impl<T> BitXor for $e<T>
-			where T: BitXor
-		{
-			type Output = $e<<T as BitXor>::Output>;
+        impl<T> BitOr for $e<T>
+        where
+            T: BitOr,
+        {
+            type Output = $e<<T as BitOr>::Output>;
 
-			#[inline]
-			fn bitxor(self,other: Self) -> Self::Output{
-				$e(self.0 ^ other.0)
-			}
-		}
+            #[inline]
+            fn bitor(self, other: Self) -> Self::Output {
+                $e(self.0 | other.0)
+            }
+        }
 
-		impl<T> $e<T>
-			where T: Sized + Copy
-		{
-			#[inline]
-			pub fn from_bytes(bytes: &[u8]) -> Self{
-				debug_assert!(bytes.len() >= mem::size_of::<T>());
-				$e(unsafe{*(bytes.as_ptr() as *const T)})
-			}
+        impl<T> BitXor for $e<T>
+        where
+            T: BitXor,
+        {
+            type Output = $e<<T as BitXor>::Output>;
 
-			#[inline]
-			pub fn as_bytes(&self) -> &[u8]{
-				unsafe{slice::from_raw_parts(
-					&self.0 as *const T as *const u8,
-					mem::size_of::<T>()
-				)}
-			}
+            #[inline]
+            fn bitxor(self, other: Self) -> Self::Output {
+                $e(self.0 ^ other.0)
+            }
+        }
 
-			/*pub fn write_bytes(self,buffer: &mut [u8]){
-				debug_assert!(buffer.len() >= mem::size_of::<T>());
-				let bytes = mem::transmute::<_,[u8; mem::size_of::<T>()]>();
-				unsafe{ptr::copy_nonoverlapping(bytes.as_ptr(),buffer.as_mut_ptr(),mem::size_of::<T>())};
-			}*/
-		}
-	}
+        impl<T> $e<T>
+        where
+            T: Sized + Copy,
+        {
+            #[inline]
+            pub fn from_bytes(bytes: &[u8]) -> Self {
+                debug_assert!(bytes.len() >= mem::size_of::<T>());
+                $e(unsafe { *(bytes.as_ptr() as *const T) })
+            }
+
+            #[inline]
+            pub fn as_bytes(&self) -> &[u8] {
+                unsafe { slice::from_raw_parts(&self.0 as *const T as *const u8, mem::size_of::<T>()) }
+            }
+        }
+    }
 }
-
-
 
 ///Big endian byte order
 ///
 ///Most significant byte first
-#[derive(Copy,Clone,Debug,Eq,PartialEq,Hash,Ord,PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct BigEndian<T>(T);
-impl<T> Endian<T> for BigEndian<T>{}
-macro_rules! impl_for_BigEndian{
-	( $t:ident ) => {
-		impl Into<$t> for BigEndian<$t>{
-			#[inline]
-			fn into(self) -> $t{
-				$t::from_be(self.0)
-			}
-		}
 
-		impl From<$t> for BigEndian<$t>{
-			#[inline]
-			fn from(data: $t) -> Self{
-				BigEndian(data.to_be())
-			}
-		}
+impl<T> Endian<T> for BigEndian<T> {}
+impl<T> Deref for BigEndian<T> {
+    type Target = T;
 
-		impl From<LittleEndian<$t>> for BigEndian<$t>{
-			#[inline]
-			fn from(data: LittleEndian<$t>) -> Self{
-				BigEndian(data.0.swap_bytes())
-			}
-		}
-	}
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
+impl<T> DerefMut for BigEndian<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+macro_rules! impl_for_BigEndian {
+    ( $t:ident ) => {
+        impl From<BigEndian<$t>> for $t {
+            #[inline]
+            fn from(data: BigEndian<$t>) -> $t {
+                $t::from_be(data.0)
+            }
+        }
+
+        impl From<$t> for BigEndian<$t> {
+            #[inline]
+            fn from(data: $t) -> Self {
+                BigEndian(data.to_be())
+            }
+        }
+
+        impl From<LittleEndian<$t>> for BigEndian<$t> {
+            #[inline]
+            fn from(data: LittleEndian<$t>) -> Self {
+                BigEndian(data.0.swap_bytes())
+            }
+        }
+    };
+}
+
 impl_Endian!(for BigEndian);
 impl_for_BigEndian!(u16);
 impl_for_BigEndian!(u32);
 impl_for_BigEndian!(u64);
+impl_for_BigEndian!(u128);
 impl_for_BigEndian!(usize);
 impl_for_BigEndian!(i16);
 impl_for_BigEndian!(i32);
 impl_for_BigEndian!(i64);
+impl_for_BigEndian!(i128);
 impl_for_BigEndian!(isize);
-
-
 
 ///Little endian byte order
 ///
 ///Least significant byte first
-#[derive(Copy,Clone,Debug,Eq,PartialEq,Hash,Ord,PartialOrd)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct LittleEndian<T>(T);
-impl<T> Endian<T> for LittleEndian<T>{}
-macro_rules! impl_for_LittleEndian{
-	( $t:ident ) => {
-		impl Into<$t> for LittleEndian<$t>{
-			#[inline]
-			fn into(self) -> $t{
-				$t::from_le(self.0)
-			}
-		}
 
-		impl From<$t> for LittleEndian<$t>{
-			#[inline]
-			fn from(data: $t) -> Self{
-				LittleEndian(data.to_le())
-			}
-		}
+impl<T> Endian<T> for LittleEndian<T> {}
+impl<T> Deref for LittleEndian<T> {
+    type Target = T;
 
-		impl From<BigEndian<$t>> for LittleEndian<$t>{
-			#[inline]
-			fn from(data: BigEndian<$t>) -> Self{
-				LittleEndian(data.0.swap_bytes())
-			}
-		}
-	}
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
+impl<T> DerefMut for LittleEndian<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+macro_rules! impl_for_LittleEndian {
+    ( $t:ident ) => {
+        impl From<LittleEndian<$t>> for $t {
+            #[inline]
+            fn from(data: LittleEndian<$t>) -> $t {
+                $t::from_le(data.0)
+            }
+        }
+
+        impl From<$t> for LittleEndian<$t> {
+            #[inline]
+            fn from(data: $t) -> Self {
+                LittleEndian(data.to_le())
+            }
+        }
+
+        impl From<BigEndian<$t>> for LittleEndian<$t> {
+            #[inline]
+            fn from(data: BigEndian<$t>) -> Self {
+                LittleEndian(data.0.swap_bytes())
+            }
+        }
+    };
+}
+
 impl_Endian!(for LittleEndian);
 impl_for_LittleEndian!(u16);
 impl_for_LittleEndian!(u32);
 impl_for_LittleEndian!(u64);
+impl_for_LittleEndian!(u128);
 impl_for_LittleEndian!(usize);
 impl_for_LittleEndian!(i16);
 impl_for_LittleEndian!(i32);
 impl_for_LittleEndian!(i64);
+impl_for_LittleEndian!(i128);
 impl_for_LittleEndian!(isize);
 
-
-///Network byte order as defined by IETF RFC1700 [http://tools.ietf.org/html/rfc1700]
+///Network byte order as defined by IETF RFC1700 <http://tools.ietf.org/html/rfc1700>
 pub type NetworkOrder<T> = BigEndian<T>;
 
-
 ///Type aliases for primitive types
-pub mod types{
-	#![allow(non_camel_case_types)]
+pub mod types {
+    #![allow(non_camel_case_types)]
 
-	use super::*;
+    use super::*;
 
-	pub type i16_be   = BigEndian<i16>;
-	pub type i32_be   = BigEndian<i32>;
-	pub type i64_be   = BigEndian<i64>;
-	pub type isize_be = BigEndian<isize>;
+    pub type i16_be = BigEndian<i16>;
+    pub type i32_be = BigEndian<i32>;
+    pub type i64_be = BigEndian<i64>;
+    pub type i128_be = BigEndian<i128>;
+    pub type isize_be = BigEndian<isize>;
 
-	pub type u16_be   = BigEndian<u16>;
-	pub type u32_be   = BigEndian<u32>;
-	pub type u64_be   = BigEndian<u64>;
-	pub type usize_be = BigEndian<usize>;
+    pub type u16_be = BigEndian<u16>;
+    pub type u32_be = BigEndian<u32>;
+    pub type u64_be = BigEndian<u64>;
+    pub type u128_be = BigEndian<u128>;
+    pub type usize_be = BigEndian<usize>;
 
-	pub type i16_le   = LittleEndian<i16>;
-	pub type i32_le   = LittleEndian<i32>;
-	pub type i64_le   = LittleEndian<i64>;
-	pub type isize_le = LittleEndian<isize>;
+    pub type i16_le = LittleEndian<i16>;
+    pub type i32_le = LittleEndian<i32>;
+    pub type i64_le = LittleEndian<i64>;
+    pub type i128_le = LittleEndian<i128>;
+    pub type isize_le = LittleEndian<isize>;
 
-	pub type u16_le   = LittleEndian<u16>;
-	pub type u32_le   = LittleEndian<u32>;
-	pub type u64_le   = LittleEndian<u64>;
-	pub type usize_le = LittleEndian<usize>;
+    pub type u16_le = LittleEndian<u16>;
+    pub type u32_le = LittleEndian<u32>;
+    pub type u64_le = LittleEndian<u64>;
+    pub type u128_le = LittleEndian<u128>;
+    pub type usize_le = LittleEndian<usize>;
 
-	pub type i16_net   = NetworkOrder<i16>;
-	pub type i32_net   = NetworkOrder<i32>;
-	pub type i64_net   = NetworkOrder<i64>;
-	pub type isize_net = NetworkOrder<isize>;
+    pub type i16_net = NetworkOrder<i16>;
+    pub type i32_net = NetworkOrder<i32>;
+    pub type i128_net = NetworkOrder<i128>;
+    pub type isize_net = NetworkOrder<isize>;
 
-	pub type u16_net   = NetworkOrder<u16>;
-	pub type u32_net   = NetworkOrder<u32>;
-	pub type u64_net   = NetworkOrder<u64>;
-	pub type usize_net = NetworkOrder<usize>;
+    pub type u16_net = NetworkOrder<u16>;
+    pub type u32_net = NetworkOrder<u32>;
+    pub type u64_net = NetworkOrder<u64>;
+    pub type u128_net = NetworkOrder<u128>;
+    pub type usize_net = NetworkOrder<usize>;
 }
-
-/*#[cfg(test)]
-mod tests{
-	use super::*;
-	use super::types::*;
-
-	#[test]
-	fn construct_big(){
-		//#[cfg(target_endian = "big")]{}
-
-	}
-}*/


### PR DESCRIPTION
This commit introduces the edition 2021 for the crate, and perform some tweaks.

Prior to this commit, the crate was `std`, and didn't implement `Deref` for the wrapped types. Implementing `Deref` is often beneficial - especially for base types such as integers. It will allow the user to have the native functionality of the integers while operating with the wrapped type.

The wrapped operations will naturally result in native integers and they will have to be reconstructed to the target endianness before they are returned.

Also, the crate was requiring `std`, when this is not actually needed. We perform just basic operations with memory, and these are fully supported by `core`. It will allow the types to be represented and operated under constrained environments such as WASM.